### PR TITLE
bower updated to use 'semantic' rather than 'semantic-ui'

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -25,7 +25,7 @@ module.exports = (grunt) ->
           {src: 'manifest.json', dest: 'build/', expand: true, cwd: 'src/'}
           {src: '**/*.*', dest: 'build/images', expand: true, cwd: 'src/images'}
           {src: '**/*.*', dest: 'build/fonts', expand: true, cwd: 'bower_components/font-awesome/fonts'}
-          {src: '**/*.*', dest: 'build/fonts', expand: true, cwd: 'bower_components/semantic-ui/src/fonts'}
+          {src: '**/*.*', dest: 'build/fonts', expand: true, cwd: 'bower_components/semantic/src/fonts'}
         ]
       tabs:
         files: [
@@ -93,3 +93,4 @@ module.exports = (grunt) ->
 
   grunt.registerTask 'build', ['concurrent:things', 'concat']
   grunt.registerTask 'release', ['build', 'crx', 'compress']
+  grunt.registerTask 'default', ['build']

--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "polymer": "*",
     "jquery": "~2.0.3",
-    "semantic-ui": "*",
+    "semantic": "~0.12.3",
     "font-awesome": "~4.0.3"
   }
 }

--- a/src/elements/ui-input/ui-input.less
+++ b/src/elements/ui-input/ui-input.less
@@ -1,5 +1,5 @@
 @import "../../../bower_components/font-awesome/less/font-awesome";
-@import "../../../bower_components/semantic-ui/src/elements/input";
+@import "../../../bower_components/semantic/build/less/elements/input";
 @import "../../less/variables";
 
 ui-input {

--- a/src/elements/ui-local-video/ui-local-video.less
+++ b/src/elements/ui-local-video/ui-local-video.less
@@ -1,6 +1,6 @@
 @import "../../../bower_components/font-awesome/less/font-awesome";
-@import '../../../bower_components/semantic-ui/src/collections/menu.less';
-@import '../../../bower_components/semantic-ui/src/elements/label.less';
+@import '../../../bower_components/semantic/build/less/collections/menu.less';
+@import '../../../bower_components/semantic/build/less/elements/label.less';
 @import "../../less/variables";
 
 ui-local-video {

--- a/src/elements/ui-sidebar/ui-sidebar.html
+++ b/src/elements/ui-sidebar/ui-sidebar.html
@@ -7,6 +7,6 @@
     <content></content>
   </div>
 </template>
-<script src="/bower_components/semantic-ui/src/modules/sidebar.js"></script>
+<script src="/bower_components/semantic/src/modules/sidebar.js"></script>
 <script src="./ui-sidebar.js"></script>
 </polymer-element>

--- a/src/elements/ui-sidebar/ui-sidebar.less
+++ b/src/elements/ui-sidebar/ui-sidebar.less
@@ -1,7 +1,7 @@
 @import "../../../bower_components/font-awesome/less/font-awesome";
-@import '../../../bower_components/semantic-ui/src/modules/sidebar.less';
-@import '../../../bower_components/semantic-ui/src/elements/input.less';
-@import '../../../bower_components/semantic-ui/src/elements/icon.less';
+@import '../../../bower_components/semantic/build/less/modules/sidebar.less';
+@import '../../../bower_components/semantic/build/less/elements/input.less';
+@import '../../../bower_components/semantic/build/less/elements/icon.less';
 @import "../../less/variables";
 
 

--- a/src/elements/ui-toolbar/ui-toolbar.less
+++ b/src/elements/ui-toolbar/ui-toolbar.less
@@ -1,5 +1,5 @@
 @import "../../../bower_components/font-awesome/less/font-awesome";
-@import '../../../bower_components/semantic-ui/src/collections/menu.less';
+@import '../../../bower_components/semantic/build/less/collections/menu.less';
 @import "../../less/variables";
 
 .@{fa-css-prefix}-rotate-135 { .fa-icon-rotate(135deg, 2); }

--- a/src/elements/ui-user-profile/ui-user-profile.less
+++ b/src/elements/ui-user-profile/ui-user-profile.less
@@ -1,6 +1,6 @@
 @import "../../../bower_components/font-awesome/less/font-awesome";
-@import "../../../bower_components/semantic-ui/src/elements/image";
-@import "../../../bower_components/semantic-ui/src/views/list";
+@import "../../../bower_components/semantic/build/less/elements/image";
+@import "../../../bower_components/semantic/build/less/views/list";
 @import "../../less/variables";
 
 ui-user-profile {

--- a/src/elements/ui-video-stream/ui-video-stream.less
+++ b/src/elements/ui-video-stream/ui-video-stream.less
@@ -1,6 +1,6 @@
 @import "../../../bower_components/font-awesome/less/font-awesome";
-@import '../../../bower_components/semantic-ui/src/collections/menu.less';
-@import '../../../bower_components/semantic-ui/src/elements/label.less';
+@import '../../../bower_components/semantic/build/less/collections/menu.less';
+@import '../../../bower_components/semantic/build/less/elements/label.less';
 @import "../../less/variables";
 
 


### PR DESCRIPTION
The bower package associated with 'semantic-ui' was a fork (which
no longer installs). The offical version no longer publishes the
'src' directory. So those paths had to be updated.
